### PR TITLE
Swapping bytes before converting to value

### DIFF
--- a/Source/data/registers.json
+++ b/Source/data/registers.json
@@ -1,16 +1,16 @@
 [
     {
-        "unit": 11,
+        "unit": 2,
         "startingAddress": 2,
         "dataType": 3,
         "functionCode": 4,
         "size": 4
     },
     {
-        "unit": 2,
-        "startingAddress": 6,
+        "unit": 11,
+        "startingAddress": 2,
         "dataType": 3,
         "functionCode": 4,
-        "size": 2
+        "size": 4
     }
 ]


### PR DESCRIPTION
If endianess dictates that words should be swapped. The byte array will be swapped before converting to values. 